### PR TITLE
Allow existing SNS topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ module "ecs_service_alarms" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| additional_notify_arns | Optional list of additional ARNs to notify on alarm and ok actions. | list | `<list>` | no |
 | alarm_description | The string to format and use as the alarm description. | string | `Average service %v utilization over last %d minute(s) too high over %v period(s)` | no |
 | attributes | List of attributes to add to label. | list | `<list>` | no |
 | cluster_name | The name of the ECS cluster to monitor. | string | - | yes |
 | cpu_utilization_threshold | The maximum percentage of CPU utilization average. | string | `80` | no |
+| create_sns_topic | Determines if a new sns topic will be generated. If set to false, the existing sns_topic_name variable must be set. | string | `true` | no |
 | delimiter | The delimiter to be used in labels. | string | `-` | no |
 | enabled | Whether to create all resources | string | `true` | no |
 | evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
@@ -53,6 +55,7 @@ module "ecs_service_alarms" {
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | period | Duration in seconds to evaluate for the alarm. | string | `300` | no |
 | service_name | The name of the ECS Service in the ECS cluster to monitor. | string | `` | no |
+| sns_topic_name | Name of existing SNS topic to use for alarm and ok actions, instead of generating a new one. | string | `` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | tags | Map of key-value pairs to use for tags. | map | `<map>` | no |
 

--- a/alarms.tf
+++ b/alarms.tf
@@ -43,8 +43,8 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   statistic           = "Average"
   threshold           = "${local.thresholds["CPUUtilizationThreshold"]}"
   alarm_description   = "${format(var.alarm_description, "CPU", var.period/60, var.evaluation_periods)}"
-  alarm_actions       = ["${aws_sns_topic.default.arn}"]
-  ok_actions          = ["${aws_sns_topic.default.arn}"]
+  alarm_actions       = ["${local.sns_topic_arn}", "${var.additional_notify_arns}"]
+  ok_actions          = ["${local.sns_topic_arn}", "${var.additional_notify_arns}"]
 
   dimensions = "${local.dimensions_map[var.service_name == "" ? "cluster" : "service"]}"
 }
@@ -60,8 +60,8 @@ resource "aws_cloudwatch_metric_alarm" "memory_utilization_too_high" {
   statistic           = "Average"
   threshold           = "${local.thresholds["MemoryUtilizationThreshold"]}"
   alarm_description   = "${format(var.alarm_description, "Memory", var.period/60, var.evaluation_periods)}"
-  alarm_actions       = ["${aws_sns_topic.default.arn}"]
-  ok_actions          = ["${aws_sns_topic.default.arn}"]
+  alarm_actions       = ["${local.sns_topic_arn}", "${var.additional_notify_arns}"]
+  ok_actions          = ["${local.sns_topic_arn}", "${var.additional_notify_arns}"]
 
   dimensions = "${local.dimensions_map[var.service_name == "" ? "cluster" : "service"]}"
 }

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,10 +3,12 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| additional_notify_arns | Optional list of additional ARNs to notify on alarm and ok actions. | list | `<list>` | no |
 | alarm_description | The string to format and use as the alarm description. | string | `Average service %v utilization over last %d minute(s) too high over %v period(s)` | no |
 | attributes | List of attributes to add to label. | list | `<list>` | no |
 | cluster_name | The name of the ECS cluster to monitor. | string | - | yes |
 | cpu_utilization_threshold | The maximum percentage of CPU utilization average. | string | `80` | no |
+| create_sns_topic | Determines if a new sns topic will be generated. If set to false, the existing sns_topic_name variable must be set. | string | `true` | no |
 | delimiter | The delimiter to be used in labels. | string | `-` | no |
 | enabled | Whether to create all resources | string | `true` | no |
 | evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
@@ -15,6 +17,7 @@
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | period | Duration in seconds to evaluate for the alarm. | string | `300` | no |
 | service_name | The name of the ECS Service in the ECS cluster to monitor. | string | `` | no |
+| sns_topic_name | Name of existing SNS topic to use for alarm and ok actions, instead of generating a new one. | string | `` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | tags | Map of key-value pairs to use for tags. | map | `<map>` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -1,23 +1,41 @@
 data "aws_caller_identity" "default" {}
 
-locals {
-  enabled = "${var.enabled == "true" ? 1 : 0}"
+module "sns_topic_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.3"
+  name       = "${var.name}"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  attributes = "${compact(concat(var.attributes, list("alarms")))}"
 }
 
-# Make a topic
+locals {
+  enabled          = "${var.enabled == "true" ? 1 : 0}"
+  create_sns_topic = "${var.create_sns_topic == "true" ? 1 : 0}"
+}
+
+data "aws_sns_topic" "default" {
+  count = "${(1 - local.create_sns_topic) * local.enabled}"
+  name  = "${var.sns_topic_name}"
+}
+
+# Create an SNS topic if one is not passed
 resource "aws_sns_topic" "default" {
-  count       = "${local.enabled}"
-  name_prefix = "ecs-service-threshold-alerts"
+  count       = "${local.enabled * local.create_sns_topic}"
+  name_prefix = "${module.sns_topic_label.id}"
+}
+
+locals {
+  sns_topic_arn = "${element(compact(concat(aws_sns_topic.default.*.arn, data.aws_sns_topic.default.*.arn, list(""))), 0)}"
 }
 
 resource "aws_sns_topic_policy" "default" {
-  count  = "${local.enabled}"
-  arn    = "${aws_sns_topic.default.arn}"
+  count  = "${local.enabled * local.create_sns_topic}"
+  arn    = "${local.sns_topic_arn}"
   policy = "${data.aws_iam_policy_document.sns_topic_policy.json}"
 }
 
 data "aws_iam_policy_document" "sns_topic_policy" {
-  count = "${local.enabled}"
+  count = "${local.enabled * local.create_sns_topic}"
 
   statement {
     actions = [
@@ -33,7 +51,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     ]
 
     effect    = "Allow"
-    resources = ["${aws_sns_topic.default.arn}"]
+    resources = ["${local.sns_topic_arn}"]
 
     principals {
       type        = "AWS"
@@ -53,7 +71,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
   statement {
     sid       = "Allow CloudwatchEvents"
     actions   = ["sns:Publish"]
-    resources = ["${aws_sns_topic.default.arn}"]
+    resources = ["${local.sns_topic_arn}"]
 
     principals {
       type        = "Service"

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,24 @@ variable "enabled" {
   default     = "true"
 }
 
+variable "create_sns_topic" {
+  type        = "string"
+  description = "Determines if a new sns topic will be generated. If set to false, the existing sns_topic_name variable must be set."
+  default     = "true"
+}
+
+variable "sns_topic_name" {
+  type        = "string"
+  description = "Name of existing SNS topic to use for alarm and ok actions, instead of generating a new one."
+  default     = ""
+}
+
+variable "additional_notify_arns" {
+  type        = "list"
+  description = "Optional list of additional ARNs to notify on alarm and ok actions."
+  default     = []
+}
+
 variable "cluster_name" {
   type        = "string"
   description = "The name of the ECS cluster to monitor."


### PR DESCRIPTION
## what
Allow an existing SNS topic to be passed in as a parameter.

## why
Give flexibility of having a single SNS topic for multiple alarm modules.