### PR TITLE
allow non-formatted alarm description

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ecs-cloudwatch-sns-alarms&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ecs-cloudwatch-sns-alarms&utm_content=website
@@ -404,3 +404,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-sns-alarms
   [share_email]: mailto:?subject=terraform-aws-ecs-cloudwatch-sns-alarms&body=https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-sns-alarms
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-ecs-cloudwatch-sns-alarms?pixel&cs=github&cm=readme&an=terraform-aws-ecs-cloudwatch-sns-alarms
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_utilization_high" {
   alarm_description = try(format(
     var.alarm_description,
     "Memory",
-    "Hight",
+    "High",
     var.memory_utilization_high_period / 60,
     var.memory_utilization_high_evaluation_periods
   ), var.alarm_description)

--- a/main.tf
+++ b/main.tf
@@ -60,13 +60,13 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_high" {
   statistic           = "Average"
   threshold           = local.thresholds["CPUUtilizationHighThreshold"]
 
-  alarm_description = format(
+  alarm_description = try(format(
     var.alarm_description,
     "CPU",
     "High",
     var.cpu_utilization_high_period / 60,
     var.cpu_utilization_high_evaluation_periods
-  )
+  ), var.alarm_description)
 
   alarm_actions = compact(var.cpu_utilization_high_alarm_actions)
   ok_actions    = compact(var.cpu_utilization_high_ok_actions)
@@ -85,13 +85,13 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_low" {
   statistic           = "Average"
   threshold           = local.thresholds["CPUUtilizationLowThreshold"]
 
-  alarm_description = format(
+  alarm_description = try(format(
     var.alarm_description,
     "CPU",
     "Low",
     var.cpu_utilization_low_period / 60,
     var.cpu_utilization_low_evaluation_periods
-  )
+  ), var.alarm_description)
 
   alarm_actions = compact(var.cpu_utilization_low_alarm_actions)
   ok_actions    = compact(var.cpu_utilization_low_ok_actions)
@@ -110,13 +110,13 @@ resource "aws_cloudwatch_metric_alarm" "memory_utilization_high" {
   statistic           = "Average"
   threshold           = local.thresholds["MemoryUtilizationHighThreshold"]
 
-  alarm_description = format(
+  alarm_description = try(format(
     var.alarm_description,
     "Memory",
     "Hight",
     var.memory_utilization_high_period / 60,
     var.memory_utilization_high_evaluation_periods
-  )
+  ), var.alarm_description)
 
   alarm_actions = compact(var.memory_utilization_high_alarm_actions)
   ok_actions    = compact(var.memory_utilization_high_ok_actions)
@@ -135,13 +135,13 @@ resource "aws_cloudwatch_metric_alarm" "memory_utilization_low" {
   statistic           = "Average"
   threshold           = local.thresholds["MemoryUtilizationLowThreshold"]
 
-  alarm_description = format(
+  alarm_description = try(format(
     var.alarm_description,
     "Memory",
     "Low",
     var.memory_utilization_low_period / 60,
     var.memory_utilization_low_evaluation_periods
-  )
+  ), var.alarm_description)
 
   alarm_actions = compact(var.memory_utilization_low_alarm_actions)
   ok_actions    = compact(var.memory_utilization_low_ok_actions)


### PR DESCRIPTION
## what
* allow `alarm_description` to be non-formatted string instead of requiring formatting

## why
* Alarms are used to trigger notifications in our on-call system. The on-call system uses alarm_description to determine which team to call. That string needs to be a team name and cannot contain additional formatted text.

## references
I've created a simplified example of the problem.

Below is an example of the error triggered by passing a non-formattable string.
![image](https://user-images.githubusercontent.com/9574264/192658536-ee7c7b40-5d78-4d81-b9a3-febf2cbfe8d5.png)

And here's an example with the solution.
![image](https://user-images.githubusercontent.com/9574264/192658771-79fb3dc8-31ce-498a-ae36-45a21d91dc08.png)


Related PR - https://github.com/cloudposse/terraform-aws-alb-target-group-cloudwatch-sns-alarms/pull/49

closes https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-sns-alarms/issues/33