### PR TITLE
Support AWS Provider V5

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'examples/**'
       - 'test/**'
+      - 'README.*'
 
 permissions:
   contents: write

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@main

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,24 +3,22 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "cloudposse/vpc/aws"
-  version    = "0.18.2"
-  cidr_block = var.vpc_cidr_block
-
-  context = module.this.context
+  source                  = "cloudposse/vpc/aws"
+  version                 = "2.1.0"
+  ipv4_primary_cidr_block = var.vpc_cidr_block
+  context                 = module.this.context
 }
 
 module "subnets" {
   source               = "cloudposse/dynamic-subnets/aws"
-  version              = "0.36.0"
+  version              = "2.3.0"
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
-  igw_id               = module.vpc.igw_id
-  cidr_block           = module.vpc.vpc_cidr_block
-  nat_gateway_enabled  = true
+  igw_id               = [module.vpc.igw_id]
+  ipv4_cidr_block      = [module.vpc.vpc_cidr_block]
+  nat_gateway_enabled  = false
   nat_instance_enabled = false
-
-  context = module.this.context
+  context              = module.this.context
 }
 
 resource "aws_ecs_cluster" "default" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,39 +1,39 @@
 output "cpu_utilization_high_cloudwatch_metric_alarm_id" {
-  value       = join("", aws_cloudwatch_metric_alarm.cpu_utilization_high.*.id)
+  value       = join("", aws_cloudwatch_metric_alarm.cpu_utilization_high[*].id)
   description = "CPU utilization high CloudWatch metric alarm ID"
 }
 
 output "cpu_utilization_high_cloudwatch_metric_alarm_arn" {
-  value       = join("", aws_cloudwatch_metric_alarm.cpu_utilization_high.*.arn)
+  value       = join("", aws_cloudwatch_metric_alarm.cpu_utilization_high[*].arn)
   description = "CPU utilization high CloudWatch metric alarm ARN"
 }
 
 output "cpu_utilization_low_cloudwatch_metric_alarm_id" {
-  value       = join("", aws_cloudwatch_metric_alarm.cpu_utilization_low.*.id)
+  value       = join("", aws_cloudwatch_metric_alarm.cpu_utilization_low[*].id)
   description = "CPU utilization low CloudWatch metric alarm ID"
 }
 
 output "cpu_utilization_low_cloudwatch_metric_alarm_arn" {
-  value       = join("", aws_cloudwatch_metric_alarm.cpu_utilization_low.*.arn)
+  value       = join("", aws_cloudwatch_metric_alarm.cpu_utilization_low[*].arn)
   description = "CPU utilization low CloudWatch metric alarm ARN"
 }
 
 output "memory_utilization_high_cloudwatch_metric_alarm_id" {
-  value       = join("", aws_cloudwatch_metric_alarm.memory_utilization_high.*.id)
+  value       = join("", aws_cloudwatch_metric_alarm.memory_utilization_high[*].id)
   description = "Memory utilization high CloudWatch metric alarm ID"
 }
 
 output "memory_utilization_high_cloudwatch_metric_alarm_arn" {
-  value       = join("", aws_cloudwatch_metric_alarm.memory_utilization_high.*.arn)
+  value       = join("", aws_cloudwatch_metric_alarm.memory_utilization_high[*].arn)
   description = "Memory utilization high CloudWatch metric alarm ARN"
 }
 
 output "memory_utilization_low_cloudwatch_metric_alarm_id" {
-  value       = join("", aws_cloudwatch_metric_alarm.memory_utilization_low.*.id)
+  value       = join("", aws_cloudwatch_metric_alarm.memory_utilization_low[*].id)
   description = "Memory utilization low CloudWatch metric alarm ID"
 }
 
 output "memory_utilization_low_cloudwatch_metric_alarm_arn" {
-  value       = join("", aws_cloudwatch_metric_alarm.memory_utilization_low.*.arn)
+  value       = join("", aws_cloudwatch_metric_alarm.memory_utilization_low[*].arn)
   description = "Memory utilization low CloudWatch metric alarm ARN"
 }


### PR DESCRIPTION
## what

Support AWS Provider V5
Linter fixes

## why

Maintenance

## references

https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0
