### PR TITLE
Avoid creating alarms for zero thresholds

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ locals {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_high" {
-  count               = module.this.enabled ? 1 : 0
+  count               = module.this.enabled && local.thresholds["CPUUtilizationHighThreshold"] > 0 ? 1 : 0
   alarm_name          = module.cpu_utilization_high_alarm_label.id
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.cpu_utilization_high_evaluation_periods
@@ -75,7 +75,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_low" {
-  count               = module.this.enabled ? 1 : 0
+  count               = module.this.enabled && local.thresholds["CPUUtilizationLowThreshold"] > 0 ? 1 : 0
   alarm_name          = module.cpu_utilization_low_alarm_label.id
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.cpu_utilization_low_evaluation_periods
@@ -100,7 +100,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_utilization_high" {
-  count               = module.this.enabled ? 1 : 0
+  count               = module.this.enabled && local.thresholds["MemoryUtilizationHighThreshold"] > 0 ? 1 : 0
   alarm_name          = module.memory_utilization_high_alarm_label.id
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.memory_utilization_high_evaluation_periods
@@ -125,7 +125,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_utilization_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_utilization_low" {
-  count               = module.this.enabled ? 1 : 0
+  count               = module.this.enabled && local.thresholds["MemoryUtilizationLowThreshold"] > 0 ? 1 : 0
   alarm_name          = module.memory_utilization_low_alarm_label.id
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.memory_utilization_low_evaluation_periods


### PR DESCRIPTION
## what

This change allows users to disable some of the alarms, by providing zero threshold.

## why

At the moment, setting zero as threshold (e.g. to disable alarms on low CPU utilization) still creates the alarm, and incurs in CloudWatch cost for a no-op alarm.
